### PR TITLE
Basic assignment model

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -18,6 +18,7 @@ makedocs(
         "Models" => [
             "Structure Frames" => "structs/sfs.md",
             # "HBond Dictionary" => "structs/hbdict.md"
+            "Assignments" => "structs/assignments.md"
         ],
         # "Hydrogen bonding model" => "hbond.md",
         # "Secondary structure" => "secstruct.md",

--- a/docs/src/structs/assignments.md
+++ b/docs/src/structs/assignments.md
@@ -1,0 +1,89 @@
+# Assignment model
+
+The model features an assignment model that can be used to build assignment
+schemes and can be extended. As of writing, plans for the assignment model is
+described in the next section.
+
+## Overview
+
+Main logic is done by the action of an `AbstractCriterion` on a set of arguments
+to yield an `AbstractAssignment`. While `AbstractCriterion` objects are callable,
+they are not subtypes of `Base.Callable`. So far, the only defined criteria
+subtypes are `DiscreteCriterion` and `CompoundCriterion`.
+
+The expectated behavior is that `AbstractAssignment` subtypes behave _similarly_
+as [enum] "flags" and that the usual basic operations on integers: `+`, `-`,
+`&`, and `|` can be applied.
+Criterion types are parametrized by the assignment type they yield, and collections
+of criteria with the same yielded assignment type can be "squashed" to create
+compound criteria.
+
+## Assignments and the assignment macro
+
+Assignments can be treated as flags (assignment flags) and can be combined to
+yield complex assignments. Assignment types are subtypes of `AbstractAssignment`,
+and are expected to have property `val`. For example, the following is a minimal
+valid definition:
+
+```julia
+struct DSSPAlphaType <: AbstractAssignment
+    val::Int32
+end
+const NoAssign   = DSSPAlphaType(0)
+const ShortTurn = DSSPAlphaType(1)
+const AlphaTurn = DSSPAlphaType(2)
+const PiTurn    = DSSPAlphaType(4)
+```
+
+The above code defined `DSSPAlphaType` as an assignment with integer field `val`.
+Top-level constants are defined so that they can be used within the program/module.
+
+!!! tip "Top-level assignments"
+    
+    It is recommended to declare assignments as top-level elements for clarity.
+
+The above seven line declaration can be shortened to a more compact form using the
+`ProtStructs.@Assignment` macro. The behavior of the macro is not yet final, and
+hence is not exported:
+
+```julia
+ProtStructs.@Assignment DSSPAlphaType NoAssign=0 ShortTurn=1 AlphaTurn=2 PiTurn=4
+```
+
+## Discrete criteria
+
+A very common way of assigning something to an object is that it is given when the
+object follows a certain condition. Otherwise, a default assignment is given. Since
+this criterion acts as a yes-no switch, it is called a _discrete criterion_.
+
+As examples, suppose you want to know when a specific ``n``-turn is present.
+To learn more about the ``n``-turn variants, check the docs for 
+[nturn](../API.md#ProtStructs.nturn).
+`DiscreteCriterion` objects are constructed as follows:
+
+```julia
+criterion1 = DiscreteCriterion(alphaturn, AlphaTurn, NoAssign)
+criterion2 = DiscreteCriterion(shortturn, ShortTurn, NoAssign)
+criterion3 = DiscreteCriterion(piturn, PiTurn, NoAssign)
+```
+
+## Squashing and compound criteria
+
+The collection of criteria above can be "squashed" into a `CompoundCriterion` as
+follows:
+
+```julia
+alphasquash = squash(criterion1, criterion2, criterion3)
+```
+
+This should work when the input criteria can accept the same numbers and types of
+arguments.
+
+## Future plans
+
+The above described behavior is experimental, and will change depending on future
+needs. Other features to be included are the following:
++ Support for blocks in assignment declaration using macro
++ Other forms of criteria aside from discrete and compound
++ Assignment blocks and layers
+

--- a/src/Assignments.jl
+++ b/src/Assignments.jl
@@ -36,7 +36,7 @@ end
 
 ## TODO: For now, stick with these two squash ops; build more i think
 
-function squash(reduction, criterion::AC{A}...) where A<:AA
+function squash(reduction::Function, criterion::AC{A}...) where A<:AA
     return CompoundCriterion{A}(reduction, criterion)
 end
 squash(criterion...) = squash(Base.:+, criterion...)

--- a/src/Assignments.jl
+++ b/src/Assignments.jl
@@ -1,22 +1,13 @@
 ## Assignments.jl --- for secondary structure assignments/classifications
 
 abstract type AbstractAssignmentLayer end
-abstract type AbstractAssignment <: Integer end
+abstract type AbstractAssignment end
 abstract type AbstractCriterion{A<:AbstractAssignment} end
 
 const AA = AbstractAssignment
 const AC = AbstractCriterion
 
 assignmenttype(::Type{<:AC{A}}) where A = A
-
-### TODO: operations on subtypes of AbstractAssignment
-for op in (:+, :-, :|, :&)
-    @eval begin
-        function Base.$op(a1::A, a2::A) where A <: AA
-            (Int32(a1) + Int32(a2)) |> A
-        end
-    end
-end
 
 struct DiscreteCriterion{A} <: AC{A}
     func::F where F <: Function
@@ -30,7 +21,7 @@ end
 
 struct CompoundCriterion{A} <: AC{A}
     reduction::F where F <: Function
-    collection::NTuple{N,C{A}} where C<:AC
+    collection::NTuple{N,C} where {C<:AC,N}
 end
 function (cc::CompoundCriterion)(x...; kwargs...)
     (; reduction, collection) = cc
@@ -41,8 +32,68 @@ end
 
 ## TODO: For now, stick with these two squash ops; build more i think
 
-function squash(reduction, criterion::C{A}...) where C<:AC
+function squash(reduction, criterion::AC{A}...) where A<:AA
     return CompoundCriterion{A}(reduction, criterion)
 end
-squash(criterion::C...) = squash(Base.:+, criterion...)
+squash(criterion...) = squash(Base.:+, criterion...)
+
+### TODO: operations on subtypes of AbstractAssignment
+## an expectation is that AA objects have property/field val
+for op in (:+, :-, :|, :&)
+    @eval begin
+        function Base.$op(a1::A, a2::A) where A <: AA
+            val = Base.$op(a1.val, a2.val)
+            return A(val)
+        end
+    end
+end
+
+macro Assignment(T, exs...)
+    ## create the type T as subtype of AA and look through the exs
+    ## behavior is very similar to enum construction
+    syms = Vector{Symbol}()
+    values = Vector{Int32}()
+
+    ## TODO: support for begin blocks (these probs shouldn't get long anyway)
+    exs[1].head === :block && error("Begin blocks aren't supported yet.")
+    
+    ## for each expression in exs check keys and vals if they are there
+    for ex in exs
+        ## for now assert that all have = as head
+        @assert ex isa Expr && ex.head === :(=) "Should be an assignment"
+        i = ex.args[2]
+        isa(i, Integer) || throw(ArgumentError("assigned value should at least be an integer; got $i"))
+        i = convert(Int32, i)
+        s = ex.args[1]
+        s = s::Symbol
+        
+        ## check if s is a valid identifier name
+        Base.isidentifier(s) || throw(ArgumentError("symbol name must be a valid identifier; got $s"))
+        ## values in i, symbol in s, lookup in both vectors
+        i in values && throw(ArgumentError("assigned values must be unique"))
+
+        ## reaching here means symbol and value are so far valid
+        push!(syms, s); push!(values, i)
+
+        ## TODO: some mechanism for order of values??
+    end
+
+    blk = quote
+        struct $(esc(T)) <: AbstractAssignment
+            val::Int32
+        end
+        ## TODO: still check for values in construction??
+        let insts = (Any[Pair(s, i) for (s, i) in zip($(syms), $(values))]...,)
+            Base.instances(::Type{$(esc(T))}) = insts
+        end
+    end
+
+    for (s, v) in zip(syms, values)
+        push!(blk.args, :(const $(esc(s)) = $(esc(T))($v)))
+    end
+    ## I guess this is to make sure nothing is printed out
+    push!(blk.args, :nothing)
+
+    return blk
+end
 

--- a/src/Assignments.jl
+++ b/src/Assignments.jl
@@ -1,5 +1,9 @@
 ## Assignments.jl --- for secondary structure assignments/classifications
 
+export AbstractAssignment, AbstractCriterion
+export DiscreteCriterion, CompoundCriterion, squash
+export assignmenttype
+
 abstract type AbstractAssignmentLayer end
 abstract type AbstractAssignment end
 abstract type AbstractCriterion{A<:AbstractAssignment} end
@@ -48,6 +52,8 @@ for op in (:+, :-, :|, :&)
     end
 end
 
+Base.:(==)(a1::A, a2::A) where A <: AA = (a1.val == a2.val)
+
 macro Assignment(T, exs...)
     ## create the type T as subtype of AA and look through the exs
     ## behavior is very similar to enum construction
@@ -93,6 +99,7 @@ macro Assignment(T, exs...)
     end
     ## I guess this is to make sure nothing is printed out
     push!(blk.args, :nothing)
+    blk.head = :toplevel
 
     return blk
 end

--- a/src/Assignments.jl
+++ b/src/Assignments.jl
@@ -1,19 +1,48 @@
 ## Assignments.jl --- for secondary structure assignments/classifications
 
-"""
-    abstract type AssignmentScheme
+abstract type AbstractAssignmentLayer end
+abstract type AbstractAssignment <: Integer end
+abstract type AbstractCriterion{A<:AbstractAssignment} end
 
-Supertype of all secondary structure assignment schemes. Plans are to implement 
-DSSP, STRIDE, KAKSI, (three-state) HEO schemes.
-"""
-abstract type AssignmentScheme end
+const AA = AbstractAssignment
+const AC = AbstractCriterion
 
-struct DSSP <: AssignmentScheme end
-struct STRIDE <: AssignmentScheme end
-struct KAKSI <: AssignmentScheme end
-struct HEO <: AssignmentScheme end
+assignmenttype(::Type{<:AC{A}}) where A = A
 
-### TODO: declare enums for secondary structures assigned by each scheme
-### TODO: abstraction for creating and applying assignment criteria
-### TODO: calculation of criteria specifics (in respective files)
+### TODO: operations on subtypes of AbstractAssignment
+for op in (:+, :-, :|, :&)
+    @eval begin
+        function Base.$op(a1::A, a2::A) where A <: AA
+            (Int32(a1) + Int32(a2)) |> A
+        end
+    end
+end
+
+struct DiscreteCriterion{A} <: AC{A}
+    func::F where F <: Function
+    assignment::A
+    fallback::A
+end
+function (dc::DiscreteCriterion)(x...; kwargs...)
+    dc.func(x...; kwargs...) && return dc.assignment
+    return dc.fallback
+end
+
+struct CompoundCriterion{A} <: AC{A}
+    reduction::F where F <: Function
+    collection::NTuple{N,C{A}} where C<:AC
+end
+function (cc::CompoundCriterion)(x...; kwargs...)
+    (; reduction, collection) = cc
+    return mapreduce(reduction, collection) do criterion
+        criterion(x...; kwargs...)
+    end
+end
+
+## TODO: For now, stick with these two squash ops; build more i think
+
+function squash(reduction, criterion::C{A}...) where C<:AC
+    return CompoundCriterion{A}(reduction, criterion)
+end
+squash(criterion::C...) = squash(Base.:+, criterion...)
 

--- a/test/assignments.jl
+++ b/test/assignments.jl
@@ -1,0 +1,23 @@
+## test/assignments.jl ---  check if constructs work as expected
+
+@testset "AbstractAssignment stuff" begin
+
+    @testset "Assignment macro" begin
+        @test DSSPAlphaTypes <: AbstractAssignment
+        @test typeof(Short) == typeof(Alpha) == typeof(Pi) == DSSPAlphaTypes
+        @test Short.val == 3 && Alpha.val == 4 && Pi.val == 5
+    end
+
+    @testset "Basic assignment operations" begin
+        @test (Short + Pi).val == 8
+        @test (Pi - Short).val == 2
+        @test (Short | NoAssign) == Short
+        @test (Short & NoAssign) == NoAssign
+    end
+
+end
+
+@testset "Criteria stuff" begin
+
+end
+

--- a/test/assignments.jl
+++ b/test/assignments.jl
@@ -5,12 +5,12 @@
     @testset "Assignment macro" begin
         @test DSSPAlphaTypes <: AbstractAssignment
         @test typeof(Short) == typeof(Alpha) == typeof(Pi) == DSSPAlphaTypes
-        @test Short.val == 3 && Alpha.val == 4 && Pi.val == 5
+        @test Short.val == 1 && Alpha.val == 2 && Pi.val == 4
     end
 
     @testset "Basic assignment operations" begin
-        @test (Short + Pi).val == 8
-        @test (Pi - Short).val == 2
+        @test (Short + Pi).val == 5
+        @test (Pi - Short).val == 3
         @test (Short | NoAssign) == Short
         @test (Short & NoAssign) == NoAssign
     end
@@ -18,6 +18,32 @@
 end
 
 @testset "Criteria stuff" begin
+    # create squashable criteria (the same Assignment subtype)
+    criterion1 = DiscreteCriterion(alphaturn, Alpha, NoAssign)
+    criterion2 = DiscreteCriterion(shortturn, Short, NoAssign)
+    criterion3 = DiscreteCriterion(piturn, Pi, NoAssign)
 
+    @testset "Discrete criteria application" begin
+        @test criterion1(dssp_alpha_dicts,  1) == Alpha
+        @test criterion1(dssp_alpha_dicts,  2) == Alpha
+        @test criterion2(dssp_alpha_dicts,  7) == Short
+        @test criterion2(dssp_alpha_dicts,  8) == Short
+        @test criterion3(dssp_alpha_dicts, 12) == Pi
+        @test criterion3(dssp_alpha_dicts, 13) == Pi
+    end
+
+    # squashed
+    alphasquash = squash(criterion1, criterion2, criterion3)
+    @testset "Squashed criterion" begin
+        @test alphasquash isa CompoundCriterion
+        @test alphasquash(dssp_alpha_dicts,  1) & Alpha != 0
+        @test alphasquash(dssp_alpha_dicts,  2) & Alpha != 0
+        @test alphasquash(dssp_alpha_dicts,  7) & Short != 0
+        @test alphasquash(dssp_alpha_dicts,  8) & Short != 0
+        @test alphasquash(dssp_alpha_dicts, 12) & Pi    != 0
+        @test alphasquash(dssp_alpha_dicts, 13) & Pi    != 0
+    end
+
+    ## create some dummy array of hbonddicts (in utils.jl)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,9 +7,13 @@ using StaticArrays
 const dataloc = joinpath(@__DIR__, "../data")
 const fnames = read(`ls $(dataloc)`, String) |> split
 
+## additional things for assignment macro: toplevel stuff
+ProtStructs.@Assignment DSSPAlphaTypes NoAssign=0 Short=3 Alpha=4 Pi=5
+
 @testset "ProtStructs.jl" begin
     @testset "File input independent behavior" begin
         include("hbdict.jl")
+        include("assignments.jl")
     end
     for name in fnames
         global fname = name

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,13 +7,22 @@ using StaticArrays
 const dataloc = joinpath(@__DIR__, "../data")
 const fnames = read(`ls $(dataloc)`, String) |> split
 
+const CI = get(ENV, "CI", nothing) === true
+
 ## additional things for assignment macro: toplevel stuff
-ProtStructs.@Assignment DSSPAlphaTypes NoAssign=0 Short=3 Alpha=4 Pi=5
+ProtStructs.@Assignment DSSPAlphaTypes NoAssign=0 Short=1 Alpha=2 Pi=4
+
+### OTHER TEST UTILITIES
+include("utils.jl")
 
 @testset "ProtStructs.jl" begin
     @testset "File input independent behavior" begin
         include("hbdict.jl")
         include("assignments.jl")
+    end
+    CI || begin
+        println("Skipping input dependent behavior...")
+        return CI
     end
     for name in fnames
         global fname = name

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,58 @@
+## utils.jl --- other test utilities
+
+# surefire hbond energy --- always added due to "generatepair" (min energy=-11)
+const sfhbe = -12
+
+### UTIL FUNCTIONS
+
+## set up a set number of interacting pairs and populate vec
+function randpopulate!(vec::AbstractVector{<:HBondDict}, N=length(vec))
+    for _ in 1:N
+        a, b, E = generatepair(vec)
+        recordpair!(vec, a, b, E)
+    end
+    return vec
+end
+
+## randomly generate an interacting pair from the indices
+function generatepair(vec::AbstractVector{<:HBondDict})
+    # define the interacting pair
+    idcs = eachindex(vec)
+    a = b = 0
+    while a == b
+        a, b = rand(idcs), rand(idcs)
+    end
+    ## now get a random energy
+    E = (rand() + 0.1) * -10.0
+    return a, b, E
+end
+
+## first index is an acceptor, while the second is a donor, 
+## interaction energy is E
+function recordpair!(vec::AbstractVector{<:HBondDict}, a, b, E)
+    dicta, dictb = vec[a], vec[b]
+    recordacceptor!(dictb, a, E)
+    @debug "recorded acceptor $a to dict $b"
+    recorddonor!(dicta, b, E)
+    @debug "recorded donor $b to dict $a"
+end
+
+### HBONDDICT FOR ASSIGNMENTS (DSSP simple test case)
+
+# DSSP internally stores 4 partner residues (2 donor/acceptor) for each backbone
+# residue
+const dssp_alpha_dicts = map(i->HBondDict(2), 1:20)
+randpopulate!(dssp_alpha_dicts)
+
+# add an alpha turn from 1-5, 2-6
+recordpair!(dssp_alpha_dicts,  1,  5, sfhbe)
+recordpair!(dssp_alpha_dicts,  2,  6, sfhbe)
+# add a short turn from 7-10, 8-11
+recordpair!(dssp_alpha_dicts,  7, 10, sfhbe)
+recordpair!(dssp_alpha_dicts,  8, 11, sfhbe)
+# add a long turn from 12-17, 13-18
+recordpair!(dssp_alpha_dicts, 12, 17, sfhbe)
+recordpair!(dssp_alpha_dicts, 13, 18, sfhbe)
+
+# add bridges --- how tho lmao
+


### PR DESCRIPTION
This PR includes a minimalistic assignments model:

- assignments as flags with `Integer`-like behavior
- criteria definition and "squashing"

See some examples in tests for how these work. Docs for these are still incomplete.
Merging is ok, but development on this branch is still recommended. 